### PR TITLE
Improve path parsing

### DIFF
--- a/script.js
+++ b/script.js
@@ -49,7 +49,12 @@ function parsePath(d, W, H, scale) {
 
     for (const s of cmds) {
         const c = s[0], C = c.toUpperCase(), rel = c !== C;
-        const v = s.slice(1).trim().split(/[ ,]+/).filter(Boolean).map(Number);
+        // Extract numeric tokens (including negatives and decimals) from the
+        // command string. Regex breakdown:
+        //  [-+]?            -> optional sign
+        //  (?:\d*\.\d+|\d+) -> decimal numbers with optional leading digits or integers
+        const v = (s.slice(1).trim().match(/[-+]?(?:\d*\.\d+|\d+)/g) || [])
+            .map(parseFloat);
         let i = 0;
 
         switch (C) {


### PR DESCRIPTION
## Summary
- enhance `parsePath` to extract numbers using a regex
- add inline comments explaining the regex

## Testing
- `node -e "const fs=require('fs');const script=fs.readFileSync('script.js','utf8');const match=script.match(/function parsePath[\s\S]*?\n}\n/);const vm=require('vm');const ctx={};vm.createContext(ctx);vm.runInContext(match[0],ctx);console.log(ctx.parsePath('M0 0L-10-20',100,100,1));"`
- `node -e "const fs=require('fs');const script=fs.readFileSync('script.js','utf8');const match=script.match(/function parsePath[\s\S]*?\n}\n/);const vm=require('vm');const ctx={};vm.createContext(ctx);vm.runInContext(match[0],ctx);console.log(ctx.parsePath('M0 0L10-10 20-20',100,100,1));"`

------
https://chatgpt.com/codex/tasks/task_e_683f8eb65c8483278a10efc612b3b355